### PR TITLE
Dependabot設定の無効項目を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    open-pull-requests-for-security-updates-only: true
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,4 +18,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    open-pull-requests-for-security-updates-only: true


### PR DESCRIPTION
Dependabotのスキーマ検証エラーになる無効キーを削除しました。
Fixes #18 