### PR TITLE
Prettierを導入

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
+npm run format
 npm run lint

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,13 +33,16 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="min-h-screen flex flex-col">
-          <header className="px-6 py-4 border-b border-black/10">
+        <div className="flex min-h-screen flex-col">
+          <header className="border-b border-black/10 px-6 py-4">
             <nav aria-label="sections">
               <ul className="flex justify-center gap-4 text-sm">
                 {sections.map((section) => (
                   <li key={section.url}>
-                    <Link href={section.url} className="underline underline-offset-4">
+                    <Link
+                      href={section.url}
+                      className="underline underline-offset-4"
+                    >
                       {section.label}
                     </Link>
                   </li>
@@ -48,7 +51,7 @@ export default function RootLayout({
             </nav>
           </header>
           <main className="flex-1">{children}</main>
-          <footer className="px-6 py-4 text-xs text-center">
+          <footer className="px-6 py-4 text-center text-xs">
             &copy; {new Date().getFullYear()} vuch.vu
           </footer>
         </div>

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -9,13 +9,13 @@ type DisplayLinkProps = {
 function DisplayLinks({ header, links, styles }: DisplayLinkProps) {
   return (
     <>
-      <h2 className="text-2xl mt-4 mb-2 text-center">{header}</h2>
+      <h2 className="mt-4 mb-2 text-center text-2xl">{header}</h2>
       <ul className="space-y-4">
         {links.map((link) => (
           <li key={link.url}>
             <a
               href={link.url}
-              className={`block max-w-xs mx-auto p-4 text-center rounded-lg ${styles} transition`}
+              className={`mx-auto block max-w-xs rounded-lg p-4 text-center ${styles} transition`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -47,11 +47,15 @@ export default function LinksPage() {
   const buttonStyles = "bg-sky-400 hover:bg-sky-300 text-white";
 
   return (
-    <main className="p-8 max-w-xl mx-auto">
-      <h1 className="text-4xl font-bold mb-6 text-center">リンク</h1>
+    <main className="mx-auto max-w-xl p-8">
+      <h1 className="mb-6 text-center text-4xl font-bold">リンク</h1>
       <DisplayLinks header="SNS" links={snsLinks} styles={buttonStyles} />
       <DisplayLinks header="創作" links={creatorLinks} styles={buttonStyles} />
-      <DisplayLinks header="開発" links={developerLinks} styles={buttonStyles} />
+      <DisplayLinks
+        header="開発"
+        links={developerLinks}
+        styles={buttonStyles}
+      />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function HomePage() {
   return (
-    <main className="p-8 max-w-xl mx-auto space-y-8">
+    <main className="mx-auto max-w-xl space-y-8 p-8">
       <div className="space-y-4 text-center">
         <h1 className="text-4xl font-bold">ヴヂュヴのホームページ</h1>
         <Image
@@ -10,13 +10,13 @@ export default function HomePage() {
           alt="Profile"
           width={192}
           height={192}
-          className="w-48 h-48 mx-auto"
+          className="mx-auto h-48 w-48"
         />
       </div>
 
       <section id="about" className="space-y-3">
-        <h2 className="text-xl font-semibold text-center">自己紹介</h2>
-        <p className="text-sm text-center">
+        <h2 className="text-center text-xl font-semibold">自己紹介</h2>
+        <p className="text-center text-sm">
           制作物や活動のまとめ、連絡先などをこのサイトに整理しています。
         </p>
       </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "eslint": "^9",
         "eslint-config-next": "^16",
         "husky": "^9.1.7",
+        "prettier": "^3.8.1",
+        "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18",
         "typescript": "^5"
       }
@@ -5463,6 +5465,101 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.2.tgz",
+      "integrity": "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "vuch.vu",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -25,6 +28,8 @@
     "eslint": "^9",
     "eslint-config-next": "^16",
     "husky": "^9.1.7",
+    "prettier": "^3.8.1",
+    "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.18",
     "typescript": "^5"
   }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+/** @type {import('prettier').Config} */
+const config = {
+  plugins: ["prettier-plugin-tailwindcss"],
+};
+
+export default config;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+const config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./pages/**/*.{js,ts,jsx,tsx}",
@@ -12,3 +12,4 @@ module.exports = {
   plugins: [],
 };
 
+export default config;


### PR DESCRIPTION
## 概要
- `prettier` と `prettier-plugin-tailwindcss` をインストール
- `prettier.config.js` を追加（Tailwind クラスの自動ソート対応）
- `npm run format` / `npm run format:check` スクリプトを追加
- pre-commit フックでコミット前に自動フォーマット＋lint を実行するように変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)