### PR TITLE
chore: exclude eslint from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-*"
+      - dependency-name: "@eslint/*"
 
   - package-ecosystem: "github-actions"
     target-branch: "develop"


### PR DESCRIPTION
## 概要
ESLint 10 が eslint-config-next と互換性がなく、dependabot による ESLint のバージョンアップ PR がビルドを壊す問題があるため、dependabot の対象から除外する。

## 変更内容

- `.github/dependabot.yml` に `ignore` を追加
  - `eslint`
  - `eslint-*`（eslint-config-next など）
  - `@eslint/*`（@eslint/js など）

## 確認事項
- [ ] テスト追加・更新済み
- [x] 動作確認済み