### PR TITLE
fix: dependabotのチェック間隔を月1回に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
     target-branch: "develop"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -18,8 +17,7 @@ updates:
     target-branch: "develop"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## 概要
dependabotのスケジュールを週次から月次に変更。合わせて `monthly` では無効な `day: "monday"` の指定を削除した。

## 変更内容

- npm・github-actions の両エコシステムで `interval` を `monthly` に変更
- `day: "monday"` を削除（monthly には日付指定が必要なため不要）

## 確認事項
- [ ] テスト追加・更新済み
- [x] 動作確認済み