### PR TITLE
feat: pin GitHub Actions to commit hashes and remove unused cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,21 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Cache node_modules
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
-
-      - name: Cache Next.js build
-        uses: actions/cache@v5
-        with:
-          path: .next/cache
-          key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('app/**', 'public/**', 'next.config.ts') }}
-          restore-keys: |
-            nextjs-${{ hashFiles('package-lock.json') }}-
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies
         run: npm install
@@ -43,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@master
+        uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 # v0.5.1
         with:
           args: --delete --exclude "*.map"
         env:


### PR DESCRIPTION
## 概要

GitHub Actions のセキュリティ強化のため、各アクションをバージョンタグではなくコミットハッシュに固定。また、デプロイ頻度が低く7日間のキャッシュ保持期限内にヒットしないため、実効性のなかったキャッシュステップを削除。

## 変更内容

- `actions/checkout@v6` → `@df4cb1c...` (v6.0.3)
- `actions/cache@v5` → 削除（2ステップ）
- `jakejarvis/s3-sync-action@master` → `@be0c4ab...` (v0.5.1)

## 確認事項
- [ ] テスト追加・更新済み
- [x] 動作確認済み