### PR TITLE
feat: worksページに trickcal-spinner-verbs と tono-monogatari を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ export default function HomePage() {
           alt="Profile"
           width={192}
           height={192}
+          priority
           className="mx-auto h-48 w-48"
         />
       </div>

--- a/app/works/page.tsx
+++ b/app/works/page.tsx
@@ -15,6 +15,17 @@ const works: Work[] = [
     url: "https://github.com/vuchvu/qr-print-helper",
     icon: "qr-print-helper.png",
   },
+  {
+    title: "Trickcal Spinner Verbs",
+    description:
+      "Claude Code のスピナーメッセージをトリックカルのリソースダウンロード中の言葉に差し替えます。",
+    url: "https://github.com/vuchvu/trickcal-spinner-verbs",
+  },
+  {
+    title: "遠野物語",
+    description: "遠野物語を読み上げたり表示したりできます。",
+    url: "https://github.com/vuchvu/tono-monogatari",
+  },
 ];
 
 export default function WorksPage() {
@@ -31,7 +42,7 @@ export default function WorksPage() {
               className="flex items-center gap-4 rounded-lg border border-black/10 p-4 transition hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"
             >
               <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-black/5 dark:bg-white/10">
-                {work.icon ? (
+                {work.icon && (
                   <Image
                     src={work.icon}
                     alt={work.title}
@@ -39,10 +50,6 @@ export default function WorksPage() {
                     height={64}
                     className="h-full w-full object-cover"
                   />
-                ) : (
-                  <span className="text-2xl text-black/20 dark:text-white/20">
-                    ?
-                  </span>
                 )}
               </div>
               <div className="min-w-0">


### PR DESCRIPTION
## 概要

worksページに新規2作品を追加。あわせてアイコン未設定時の「?」プレースホルダーを削除し、トップページのLCP警告（avatar.png）に対応した。

## 変更内容

- worksページに [trickcal-spinner-verbs](https://github.com/vuchvu/trickcal-spinner-verbs) と [tono-monogatari](https://github.com/vuchvu/tono-monogatari) を追加（アイコンは未設定、別途作成予定）
- アイコン未設定時の「?」プレースホルダーを削除
- トップページのアバター画像に `priority` を追加（Next.jsのLCP警告対応）

## 確認事項

- [ ] テスト追加・更新済み
- [x] 動作確認済み（`pnpm run build` 成功、devサーバーで表示確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)