### PR TITLE
fix: /works 404とアイコン読み込み失敗を修正し、URLを末尾スラッシュなしに統一

### DIFF
--- a/app/works/page.tsx
+++ b/app/works/page.tsx
@@ -13,7 +13,7 @@ const works: Work[] = [
     description:
       "QRコード画像からPDFラベルを生成するユーティリティ。GUI・CLI両対応。",
     url: "https://github.com/vuchvu/qr-print-helper",
-    icon: "qr-print-helper.png",
+    icon: "/qr-print-helper.png",
   },
   {
     title: "Trickcal Spinner Verbs",

--- a/cdk/lib/network/cloudfront.ts
+++ b/cdk/lib/network/cloudfront.ts
@@ -17,12 +17,47 @@ export function createDistribution(
 ): cloudfront.Distribution {
   const { domain, bucket, certificate } = props;
 
+  // S3 REST API エンドポイントは拡張子なしパスを解決できないため、
+  // viewer-request で /works -> /works.html のように書き換える。
+  // URL は末尾スラッシュなしに統一し、/works/ は /works へリダイレクトする
+  // (ルート / のみ defaultRootObject が処理)
+  const rewriteIndexFunction = new cloudfront.Function(
+    scope,
+    "RewriteIndexFunction",
+    {
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  if (uri !== "/" && uri.endsWith("/")) {
+    return {
+      statusCode: 301,
+      statusDescription: "Moved Permanently",
+      headers: { location: { value: uri.replace(/\\/+$/, "") } },
+    };
+  }
+  if (uri !== "/" && !uri.includes(".")) {
+    request.uri = uri + ".html";
+  }
+  return request;
+}
+`),
+    },
+  );
+
   return new cloudfront.Distribution(scope, "Distribution", {
     defaultBehavior: {
       origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
       viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
       compress: true,
       cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      functionAssociations: [
+        {
+          function: rewriteIndexFunction,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        },
+      ],
     },
     domainNames: [domain],
     certificate,

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  trailingSlash: true,
   images: {
     unoptimized: true,
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  // ワークスペースルートの誤検出を防ぐ (親ディレクトリに別のlockfileがあっても警告しない)
+  turbopack: {
+    root: import.meta.dirname,
+  },
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## 概要
https://vuch.vu/works が404になる問題と、worksページのアイコンが読み込めない問題を修正する。

原因は2つ:
- CloudFrontのオリジンがS3 REST APIエンドポイント(OAC)で、拡張子なしパスやサブディレクトリの index.html を解決できない（`defaultRootObject` はルートのみ有効）
- アイコンの参照が相対パスで、ページURLの末尾スラッシュ有無で解決先が変わる

あわせてURLの形式を一般的な末尾スラッシュなし（`/works`）に統一する。

## 変更内容

- viewer-request の CloudFront Function を追加し、拡張子なしパス（`/works`）を `/works.html` に書き換え。末尾スラッシュ付きURL（`/works/`）は301でスラッシュなしへ正規化
- `trailingSlash: true` を削除し、Next.jsデフォルトのフラットHTML出力（`works.html` 形式）に変更
- worksページのアイコンを絶対パス `/qr-print-helper.png` で参照するよう修正
- `turbopack.root` を明示し、git worktree等でのワークスペースルート誤検出の警告を解消

## 確認事項
- [x] テスト追加・更新済み（該当テストなし。CloudFront Functionのロジックは全URIパターンをローカルでシミュレートして確認）
- [x] 動作確認済み（`pnpm build` で `out/works.html` 生成とアイコンの絶対パス参照を確認、`cdk synth`/`cdk diff` で差分が追加のみであることを確認）

## デプロイ手順（本リリース後）
1. mainへのpushでGitHub Actionsが `out/` をS3へsync（`works.html` 形式に入れ替わる）
2. その後 `cdk deploy` でCloudFront Functionを更新（この順でないと一時的に404になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)